### PR TITLE
fix(configure.sh): use jq --arg to detect already-delegated classes on re-run

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -609,7 +609,12 @@ _process_app_delegations() {
 	_existing_delegations=$(php occ admin-delegation:show --output=json 2>/dev/null || echo "[]")
 	while IFS= read -r _class; do
 		if [ -n "${_class}" ]; then
-			if echo "${_existing_delegations}" | grep -qF "${_class}"; then
+			if jq -e --arg class "${_class}" \
+				'[.[].settings[].className] | contains([$class])' \
+				>/dev/null 2>&1 <<EOF
+${_existing_delegations}
+EOF
+			then
 				log_info "Delegation for class '${_class}' already exists, skipping"
 			else
 				log_info "Adding delegation for class: ${_class}"


### PR DESCRIPTION
## Summary

`admin-delegation:show --output=json` returns class names with double-escaped backslashes (`OCA\\Activity\\Settings\\Admin`). The previous `grep -qF "${_class}"` check compared against single-backslash shell strings — they never matched, so every re-run attempted to re-add all delegations, hitting exit code 4 and logging a false `[e]` error for each class.

## Fix

Replace `grep -qF` with a `jq --arg` check:
- `--arg class "${_class}"` passes the value as a literal string — jq handles JSON decoding internally, no shell escaping needed
- `[.[].settings[].className] | contains([$class])` checks all settings across all delegation sections
- Here-document feeds `_existing_delegations` to stdin without a subshell

## Result

```
[i] Delegation for class 'OCA\Activity\Settings\Admin' already exists, skipping
[i] Delegation for class 'OCA\Mail\Settings\ProviderAccountOverviewSettings' already exists, skipping
```

## Test plan
- [ ] Second run produces 0 `[e]` lines for `admin-delegation:add`
- [ ] First run (fresh cluster) still adds all delegations correctly
- [ ] Temporarily disabled app (e.g. `files_external`) is enabled, checked, and disabled again without errors