### PR TITLE
fix(configure.sh): check delegatedGroups contains admin before skipping delegation

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -70,7 +70,11 @@ user_saml:OCA\\User_SAML\\Settings\\Admin
 # Usage: log_error <message>
 log_error() {
 	_ERROR_COUNT=$(( _ERROR_COUNT + 1 ))
-	printf '\033[1;31m[e] Error: %s\033[0m\n' "${*}" >&2
+	if [ "${PLAIN_OUTPUT}" = "false" ]; then
+		printf '\033[1;31m[e] Error: %s\033[0m\n' "${*}" >&2
+	else
+		printf '[e] Error: %s\n' "${*}" >&2
+	fi
 }
 
 # Log fatal error message and exit with failure code

--- a/configure.sh
+++ b/configure.sh
@@ -607,18 +607,18 @@ _process_app_delegations() {
 	# Use here-document (not pipe) so the loop runs in the current shell,
 	# preserving variable mutations (e.g. _ERROR_COUNT) in the parent process.
 	_existing_delegations=$(php occ admin-delegation:show --output=json 2>/dev/null || echo "[]")
-	while IFS= read -r _class; do
-		if [ -n "${_class}" ]; then
-			if jq -e --arg class "${_class}" \
+	while IFS= read -r _delegation_class; do
+		if [ -n "${_delegation_class}" ]; then
+			if jq -e --arg class "${_delegation_class}" \
 				'any(.[].settings[]; .className == $class and (.delegatedGroups | contains(["admin"])))' \
 				>/dev/null 2>&1 <<EOF
 ${_existing_delegations}
 EOF
 			then
-				log_info "Delegation for class '${_class}' already exists, skipping"
+				log_info "Delegation for class '${_delegation_class}' already exists, skipping"
 			else
-				log_info "Adding delegation for class: ${_class}"
-				execute_occ_command admin-delegation:add "${_class}" admin
+				log_info "Adding delegation for class: ${_delegation_class}"
+				execute_occ_command admin-delegation:add "${_delegation_class}" admin
 			fi
 		fi
 	done <<EOF

--- a/configure.sh
+++ b/configure.sh
@@ -70,11 +70,7 @@ user_saml:OCA\\User_SAML\\Settings\\Admin
 # Usage: log_error <message>
 log_error() {
 	_ERROR_COUNT=$(( _ERROR_COUNT + 1 ))
-	if [ "${PLAIN_OUTPUT}" = "false" ]; then
-		echo "\033[1;31m[e] Error: ${*}\033[0m" >&2
-	else
-		echo "[e] Error: ${*}" >&2
-	fi
+	printf '\033[1;31m[e] Error: %s\033[0m\n' "${*}" >&2
 }
 
 # Log fatal error message and exit with failure code

--- a/configure.sh
+++ b/configure.sh
@@ -615,7 +615,7 @@ _process_app_delegations() {
 ${_existing_delegations}
 EOF
 			then
-				log_info "Delegation for class '${_delegation_class}' already exists, skipping"
+				log_info "Delegation for class '${_delegation_class}' to group 'admin' already exists, skipping"
 			else
 				log_info "Adding delegation for class: ${_delegation_class}"
 				execute_occ_command admin-delegation:add "${_delegation_class}" admin

--- a/configure.sh
+++ b/configure.sh
@@ -606,7 +606,7 @@ _process_app_delegations() {
 	# Fetch existing delegations once to avoid errors on re-runs.
 	# Use here-document (not pipe) so the loop runs in the current shell,
 	# preserving variable mutations (e.g. _ERROR_COUNT) in the parent process.
-	_existing_delegations=$(php occ admin-delegation:show --output=json 2>/dev/null || echo "[]")
+	_existing_delegations=$(execute_occ_command admin-delegation:show --output=json 2>/dev/null || echo "[]")
 	while IFS= read -r _delegation_class; do
 		if [ -n "${_delegation_class}" ]; then
 			if jq -e --arg class "${_delegation_class}" \

--- a/configure.sh
+++ b/configure.sh
@@ -606,7 +606,11 @@ _process_app_delegations() {
 	# Fetch existing delegations once to avoid errors on re-runs.
 	# Use here-document (not pipe) so the loop runs in the current shell,
 	# preserving variable mutations (e.g. _ERROR_COUNT) in the parent process.
-	_existing_delegations=$(execute_occ_command admin-delegation:show --output=json 2>/dev/null || echo "[]")
+	_previous_error_count="${_ERROR_COUNT}"
+	if ! _existing_delegations=$(execute_occ_command admin-delegation:show --output=json 2>/dev/null); then
+		_ERROR_COUNT="${_previous_error_count}"
+		_existing_delegations="[]"
+	fi
 	while IFS= read -r _delegation_class; do
 		if [ -n "${_delegation_class}" ]; then
 			if jq -e --arg class "${_delegation_class}" \

--- a/configure.sh
+++ b/configure.sh
@@ -610,7 +610,7 @@ _process_app_delegations() {
 	while IFS= read -r _class; do
 		if [ -n "${_class}" ]; then
 			if jq -e --arg class "${_class}" \
-				'[.[].settings[].className] | contains([$class])' \
+				'any(.[].settings[]; .className == $class and (.delegatedGroups | contains(["admin"])))' \
 				>/dev/null 2>&1 <<EOF
 ${_existing_delegations}
 EOF


### PR DESCRIPTION
## Problem

`admin-delegation:show --output json` lists **all** registered settings classes, even those with an empty `delegatedGroups` array. The previous `jq` filter:

```sh
'[.[].settings[].className] | contains([$class])'
```

only checked whether `className` appeared anywhere in the output — which is always true. So every delegation was silently skipped on every re-run, logging the misleading message:

> Delegation for class '…' already exists, skipping

## Fix

Replace the filter with one that also verifies `"admin"` is present in `delegatedGroups` for the matched class:

```sh
'any(.[].settings[]; .className == $class and (.delegatedGroups | contains(["admin"])))'
```

This returns `true` only when the class is already fully configured with admin delegation — the correct "nothing to do" condition.

## Test

```sh
payload='[{"id":"mail-provider-accounts","settings":[{"className":"OCA\\Mail\\Settings\\ProviderAccountOverviewSettings","delegatedGroups":["admin"]}]},{"id":"groupware","settings":[{"className":"OCA\\Mail\\Settings\\AdminSettings","delegatedGroups":[]}]}]'

# exit 0 → skip (admin already delegated)
echo "$payload" | jq -e --arg class 'OCA\Mail\Settings\ProviderAccountOverviewSettings' \
  'any(.[].settings[]; .className == $class and (.delegatedGroups | contains(["admin"])))'

# exit 1 → add (no admin yet)
echo "$payload" | jq -e --arg class 'OCA\Mail\Settings\AdminSettings' \
  'any(.[].settings[]; .className == $class and (.delegatedGroups | contains(["admin"])))'
```