### PR TITLE
IONOS(build): remove gdata_antivirus from FULL_BUILD_APPS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,6 @@ FULL_BUILD_APPS = \
 	deck \
 	end_to_end_encryption \
 	files_pdfviewer \
-	gdata_antivirus \
 	groupfolders \
 	integration_openai \
 	mail \


### PR DESCRIPTION
## Summary

- Removes `gdata_antivirus` from the `FULL_BUILD_APPS` list in the Makefile

## Test plan

- [x] Verify that the build pipeline completes successfully without `gdata_antivirus`